### PR TITLE
Url validation fix for Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ making a given HTTP request during the retry process.  Type: `Long`, default val
 
 ### How Hermes handles responses
 
-Hermes contains no logic to automatically handle redirects at this time.  Thus, its classification of response status
-codes is nonstandard.
-
 **Status code policies:**
 
 * 2xx response codes are treated as successes.
-* 3xx and 4xx response codes are treated as failures indicating an invalid message; messages that fail with these
+* 3xx redirects will be automatically followed.
+* 4xx response codes are treated as failures indicating an invalid message; messages that fail with these
 codes are ineligible for retry.
 * 5xx response codes are treated as failures, but the message itself is still regarded as valid and eligible for
 retry.

--- a/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
@@ -19,7 +19,7 @@ class MessageCommand implements Validateable {
     def metadata
 
     static constraints = {
-        url nullable: false, url: ['localhost:\\d*', '\\p{Alnum}(?>[\\p{Alnum}-.]{0,61}\\p{Alnum})?(.local)?']
+        url nullable: false, url: ['localhost:\\d*', '\\p{Alnum}(?>[\\p{Alnum}-.]{0,61}\\p{Alnum})?']
         httpMethod nullable: false
         contentType nullable: false
         headers nullable: true

--- a/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
@@ -19,7 +19,7 @@ class MessageCommand implements Validateable {
     def metadata
 
     static constraints = {
-        url nullable: false, url: ['localhost:\\d*']
+        url nullable: false, url: ['localhost:\\d*', '\\S+.local']
         httpMethod nullable: false
         contentType nullable: false
         headers nullable: true

--- a/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
@@ -19,7 +19,7 @@ class MessageCommand implements Validateable {
     def metadata
 
     static constraints = {
-        url nullable: false, url: ['localhost:\\d*', '\\S+.local']
+        url nullable: false, url: ['localhost:\\d*', '\\p{Alnum}(?>[\\p{Alnum}-.]{0,61}\\p{Alnum})?(.local)?']
         httpMethod nullable: false
         contentType nullable: false
         headers nullable: true

--- a/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
@@ -27,6 +27,31 @@ class MessageCommandSpec extends Specification {
         'http://example.com'            | [q: 'val']                            || 'http://example.com?q=val'
     }
 
+    @Unroll("verify url validation is working correctly for url #url")
+    void "verify url validation"() {
+        given: "a MessageCommand with a given url"
+        MessageCommand cmd = new MessageCommand()
+        cmd.url = url
+
+        when: "we validate the command"
+        cmd.validate()
+
+        then: "the URL validity is calculated as expected"
+        cmd.errors.getFieldError('url') as boolean == isInvalid
+
+        where:
+        url                                                                 || isInvalid
+        'http://localhost:8080'                                             || false
+        'https://localhost:8080/bleh'                                       || false
+        'http://env-stage-mtl-mock.stage.svc.cluster.local/Notification'    || false
+        'https://test.bleh.local/1/blkf'                                    || false
+        'http:///sdf.com'                                                   || true
+        'http://sdf'                                                        || true
+        'sdf.com'                                                           || true
+        null                                                                || true
+        'http://.local'                                                     || true
+    }
+
     void "test toMap"() {
         given: "a MessageCommand"
         MessageCommand command = new MessageCommand()

--- a/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
@@ -46,7 +46,7 @@ class MessageCommandSpec extends Specification {
         'http://env-stage-mtl-mock.stage.svc.cluster.local/Notification'    || false
         'https://test.bleh.local/1/blkf'                                    || false
         'http:///sdf.com'                                                   || true
-        'http://sdf'                                                        || true
+        'http://sdf'                                                        || false
         'sdf.com'                                                           || true
         null                                                                || true
         'http://.local'                                                     || true


### PR DESCRIPTION
Hermes doesn't like some of our internal URLs.  I added a custom regex to the URL validator to allow `.local` domains.  Are there any other internal URLs I should set Hermes to accept?