### PR TITLE
Ripping out URL validation

### DIFF
--- a/hermes-plugin/build.gradle
+++ b/hermes-plugin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version "1.3.3"
+version "1.3.4"
 group "com.binxhealth"
 
 apply plugin:"eclipse"

--- a/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/binxhealth/hermes/message/MessageCommand.groovy
@@ -19,7 +19,7 @@ class MessageCommand implements Validateable {
     def metadata
 
     static constraints = {
-        url nullable: false, url: ['localhost:\\d*', '\\p{Alnum}(?>[\\p{Alnum}-.]{0,61}\\p{Alnum})?']
+        url blank: false
         httpMethod nullable: false
         contentType nullable: false
         headers nullable: true

--- a/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/binxhealth/hermes/message/MessageCommandSpec.groovy
@@ -27,31 +27,6 @@ class MessageCommandSpec extends Specification {
         'http://example.com'            | [q: 'val']                            || 'http://example.com?q=val'
     }
 
-    @Unroll("verify url validation is working correctly for url #url")
-    void "verify url validation"() {
-        given: "a MessageCommand with a given url"
-        MessageCommand cmd = new MessageCommand()
-        cmd.url = url
-
-        when: "we validate the command"
-        cmd.validate()
-
-        then: "the URL validity is calculated as expected"
-        cmd.errors.getFieldError('url') as boolean == isInvalid
-
-        where:
-        url                                                                 || isInvalid
-        'http://localhost:8080'                                             || false
-        'https://localhost:8080/bleh'                                       || false
-        'http://env-stage-mtl-mock.stage.svc.cluster.local/Notification'    || false
-        'https://test.bleh.local/1/blkf'                                    || false
-        'http:///sdf.com'                                                   || true
-        'http://sdf'                                                        || false
-        'sdf.com'                                                           || true
-        null                                                                || true
-        'http://.local'                                                     || true
-    }
-
     void "test toMap"() {
         given: "a MessageCommand"
         MessageCommand command = new MessageCommand()


### PR DESCRIPTION
The URL validation implementation in Hermes is too fragile and inflexible, and it keeps causing bugs.  Since Hermes already handles failed HTTP requests, I'm removing all the URL regex validation from `MessageCommand`.  Going forward, it will be the caller's responsibility to ensure that their URLs are correct; Hermes will naively accept any URL String it is given.